### PR TITLE
fix: rerun resumes from correct stage instead of starting fresh

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -220,7 +220,7 @@ async function main() {
   // State machine: check issue state before doing anything
   // Skip for review/resolve/rerun commands and for PR-based fix (these don't need issue resolution)
   const isPRFix = (input.command === "fix" || input.command === "fix-ci") && !!input.prNumber
-  const skipStateCheck = input.command === "review" || input.command === "resolve" || input.command === "rerun" || input.command === "status" || input.command === "compose" || input.command === "ask"
+  const skipStateCheck = input.command === "review" || input.command === "resolve" || input.command === "status" || input.command === "compose" || input.command === "ask"
   if (input.issueNumber && !skipStateCheck && !isPRFix) {
     const taskAction = resolveForIssue(input.issueNumber, projectDir)
     logger.info(`Task action: ${taskAction.action}`)


### PR DESCRIPTION
## Summary

- `rerun` was incorrectly included in `skipStateCheck` in `src/entry.ts`
- This caused `resolveForIssue()` to be skipped, so `fromStage` was never read from `status.json`
- Result: `@kody rerun` always started a fresh pipeline instead of resuming

## Fix

Removed `"rerun"` from `skipStateCheck` so it goes through the normal state machine: `resolveForIssue()` is called, reads the existing `status.json`, sets `fromStage` correctly, and the pipeline resumes from where it left off.

## Test plan

- [x] Published as v0.3.0 to npm, already installed globally  
- [ ] Merge and trigger a fresh `@kody` run to confirm normal flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)