### PR TITLE
feat(kody-lean): single-session pipeline alongside 7-stage (v0.5.0)

### DIFF
--- a/.github/workflows/kody-lean-tests.yml
+++ b/.github/workflows/kody-lean-tests.yml
@@ -1,0 +1,42 @@
+name: kody-lean tests
+
+on:
+  pull_request:
+    paths:
+      - "src-v2/**"
+      - "bin-v2/**"
+      - "tests/lean/**"
+      - "e2e/**"
+      - ".github/workflows/kody-lean-tests.yml"
+      - "package.json"
+      - "tsconfig.json"
+  push:
+    branches: [main]
+    paths:
+      - "src-v2/**"
+      - "bin-v2/**"
+      - "tests/lean/**"
+      - "e2e/**"
+
+jobs:
+  unit-and-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Configure git identity (for integration tests)
+        run: |
+          git config --global user.name  "kody-test"
+          git config --global user.email "test@kody"
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Run unit + integration tests
+        run: npx vitest run tests/lean --no-coverage
+      - name: Run E2E smoke
+        run: npx vitest run e2e --no-coverage

--- a/.github/workflows/kody-lean-tests.yml
+++ b/.github/workflows/kody-lean-tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/kody-lean.yml
+++ b/.github/workflows/kody-lean.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/kody-lean.yml
+++ b/.github/workflows/kody-lean.yml
@@ -1,0 +1,77 @@
+name: kody-lean
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "GitHub issue number"
+        required: true
+        type: string
+  issue_comment:
+    types: [created]
+
+jobs:
+  run:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request == null &&
+        contains(github.event.comment.body, '@kody2'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup Python (for LiteLLM)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install LiteLLM
+        run: pip install 'litellm[proxy]'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "kody-lean-bot"
+          git config user.email "kody-lean-bot@users.noreply.github.com"
+
+      - name: Run kody-lean
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_PAT:   ${{ secrets.GH_PAT }}
+          MINIMAX_API_KEY:   ${{ secrets.MINIMAX_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY:    ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          ISSUE="${{ github.event.inputs.issue_number || github.event.issue.number }}"
+          pnpm kody-lean run --issue "$ISSUE"
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kody-lean-run-${{ github.run_id }}
+          path: .kody-lean/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ demo/videos/
 # Test coverage
 coverage/
 .kody-engine/
+
+# kody-lean (single-session pipeline) runtime artifacts
+.kody-lean/

--- a/bin-v2/kody-lean.ts
+++ b/bin-v2/kody-lean.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { main } from "../src-v2/entry.js"
+
+main().then((code) => {
+  process.exit(code)
+}).catch((err) => {
+  process.stderr.write(`[kody-lean] fatal: ${err instanceof Error ? err.message : String(err)}\n`)
+  process.exit(99)
+})

--- a/bin-v2/kody-lean.ts
+++ b/bin-v2/kody-lean.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { main } from "../src-v2/entry.js"
 
 main().then((code) => {

--- a/e2e/dry-run.test.ts
+++ b/e2e/dry-run.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest"
+import { spawnSync } from "child_process"
+import * as path from "path"
+
+const ROOT = path.resolve(__dirname, "..")
+
+function runCli(args: string[], env: Record<string, string> = {}): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync("npx", ["tsx", "bin-v2/kody-lean.ts", ...args], {
+    cwd: ROOT,
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+    timeout: 60_000,
+  })
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+describe("e2e: CLI smoke", () => {
+  it("prints help with no args", () => {
+    const r = runCli([])
+    expect(r.code).toBe(0)
+    expect(r.stdout).toMatch(/kody-lean/)
+    expect(r.stdout).toMatch(/Usage/)
+  })
+
+  it("prints help with --help", () => {
+    const r = runCli(["--help"])
+    expect(r.code).toBe(0)
+    expect(r.stdout).toMatch(/kody-lean/)
+  })
+
+  it("prints version", () => {
+    const r = runCli(["--version"])
+    expect(r.code).toBe(0)
+    expect(r.stdout).toMatch(/0\./)
+  })
+
+  it("rejects run without --issue", () => {
+    const r = runCli(["run"])
+    expect(r.code).toBe(64)
+    expect(r.stderr).toMatch(/--issue/)
+  })
+
+  it("rejects unknown command", () => {
+    const r = runCli(["frobnicate"])
+    expect(r.code).toBe(64)
+    expect(r.stderr).toMatch(/unknown command/)
+  })
+
+  it("rejects unknown flag", () => {
+    const r = runCli(["run", "--issue", "1", "--bogus"])
+    expect(r.code).toBe(64)
+    expect(r.stderr).toMatch(/--bogus/)
+  })
+
+  it("rejects non-positive issue number", () => {
+    const r = runCli(["run", "--issue", "0"])
+    expect(r.code).toBe(64)
+    expect(r.stderr).toMatch(/positive integer/)
+  })
+})

--- a/kody.config.json
+++ b/kody.config.json
@@ -17,6 +17,7 @@
     "taskDir": ".kody/tasks"
   },
   "agent": {
+    "model": "minimax/MiniMax-M2.7-highspeed",
     "modelMap": {
       "cheap": "minimax/MiniMax-M2.7-highspeed",
       "mid": "minimax/MiniMax-M2.7-highspeed",

--- a/kody.config.schema.json
+++ b/kody.config.schema.json
@@ -86,6 +86,12 @@
       "type": "object",
       "description": "Agent execution configuration",
       "properties": {
+        "model": {
+          "type": "string",
+          "pattern": "^[^/]+/.+$",
+          "description": "Single 'provider/model' string used by kody-lean (single-session pipeline). Use 'claude/...' or 'anthropic/...' for direct Anthropic API; anything else routes through LiteLLM proxy.",
+          "examples": ["claude/claude-sonnet-4-6", "minimax/MiniMax-M2.7-highspeed"]
+        },
         "modelMap": {
           "type": "object",
           "description": "Maps model tiers to 'provider/model' strings. Use 'claude/...' or 'anthropic/...' for direct Anthropic API; anything else routes through LiteLLM proxy.",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "kody-engine": "dist/bin/cli.js"
+    "kody-engine": "dist/bin/cli.js",
+    "kody-lean": "dist/bin-v2/kody-lean.js"
   },
   "files": [
     "dist",
@@ -15,10 +16,13 @@
   ],
   "scripts": {
     "kody": "tsx src/entry.ts",
+    "kody-lean": "tsx bin-v2/kody-lean.ts",
     "claude": "tsx scripts/kody.ts",
     "build": "tsup",
     "test": "vitest run --coverage",
     "test:ci": "vitest run --coverage --reporter=junit --outputFile=coverage/junit.xml",
+    "test:lean": "vitest run --coverage src-v2",
+    "test:lean:e2e": "vitest run e2e",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm build"
   },

--- a/src-v2/agent.ts
+++ b/src-v2/agent.ts
@@ -1,0 +1,84 @@
+import { query } from "@anthropic-ai/claude-agent-sdk"
+import * as fs from "fs"
+import * as path from "path"
+import { renderEvent, type SdkMessageLike } from "./format.js"
+import { getAnthropicApiKeyOrDummy, type ProviderModel } from "./config.js"
+
+export interface AgentResult {
+  outcome: "completed" | "failed"
+  finalText: string
+  error?: string
+  ndjsonPath: string
+}
+
+export interface AgentOptions {
+  prompt: string
+  model: ProviderModel
+  cwd: string
+  litellmUrl?: string | null
+  verbose?: boolean
+  quiet?: boolean
+  ndjsonDir?: string
+}
+
+const ALLOWED_TOOLS = ["Bash", "Edit", "Read", "Write", "Glob", "Grep"]
+
+export async function runAgent(opts: AgentOptions): Promise<AgentResult> {
+  const ndjsonDir = opts.ndjsonDir ?? path.join(opts.cwd, ".kody-lean")
+  fs.mkdirSync(ndjsonDir, { recursive: true })
+  const ndjsonPath = path.join(ndjsonDir, "last-run.jsonl")
+  const fullLog = fs.createWriteStream(ndjsonPath, { flags: "w" })
+
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    SKIP_HOOKS: "1",
+    HUSKY: "0",
+    CI: process.env.CI ?? "1",
+  }
+  if (opts.litellmUrl) {
+    env.ANTHROPIC_BASE_URL = opts.litellmUrl
+    env.ANTHROPIC_API_KEY = getAnthropicApiKeyOrDummy()
+  }
+
+  let finalText = ""
+  let outcome: "completed" | "failed" = "failed"
+  let errorMessage: string | undefined
+
+  try {
+    const result = query({
+      prompt: opts.prompt,
+      options: {
+        model: opts.model.model,
+        cwd: opts.cwd,
+        allowedTools: ALLOWED_TOOLS,
+        permissionMode: "acceptEdits",
+        env,
+      },
+    })
+
+    for await (const msg of result) {
+      try { fullLog.write(JSON.stringify(msg) + "\n") } catch { /* best effort */ }
+
+      const line = renderEvent(msg as SdkMessageLike, { verbose: opts.verbose, quiet: opts.quiet })
+      if (line) process.stdout.write(line + "\n")
+
+      const m = msg as SdkMessageLike
+      if (m.type === "result") {
+        if (m.subtype === "success") {
+          outcome = "completed"
+          finalText = (typeof m.result === "string" ? m.result : "").trim()
+        } else {
+          outcome = "failed"
+          errorMessage = `result subtype: ${m.subtype ?? "unknown"}`
+        }
+      }
+    }
+  } catch (e) {
+    outcome = "failed"
+    errorMessage = e instanceof Error ? e.message : String(e)
+  } finally {
+    try { fullLog.end() } catch { /* best effort */ }
+  }
+
+  return { outcome, finalText, error: errorMessage, ndjsonPath }
+}

--- a/src-v2/branch.ts
+++ b/src-v2/branch.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "child_process"
+
+export interface BranchResult {
+  branch: string
+  created: boolean
+}
+
+export class UncommittedChangesError extends Error {
+  constructor(public branch: string) {
+    super(`Uncommitted changes on branch '${branch}' — refusing to run to protect work in progress`)
+    this.name = "UncommittedChangesError"
+  }
+}
+
+function git(args: string[], cwd?: string): string {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    timeout: 30_000,
+    cwd,
+    env: { ...process.env, HUSKY: "0", SKIP_HOOKS: "1" },
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim()
+}
+
+export function deriveBranchName(issueNumber: number, title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 50)
+    .replace(/-$/, "")
+  return slug ? `${issueNumber}-${slug}` : `${issueNumber}`
+}
+
+export function getCurrentBranch(cwd?: string): string {
+  return git(["branch", "--show-current"], cwd)
+}
+
+export function hasUncommittedChanges(cwd?: string): boolean {
+  return git(["status", "--porcelain"], cwd).length > 0
+}
+
+export function ensureFeatureBranch(
+  issueNumber: number,
+  title: string,
+  defaultBranch: string,
+  cwd?: string,
+): BranchResult {
+  const branchName = deriveBranchName(issueNumber, title)
+  const current = getCurrentBranch(cwd)
+
+  if (current === branchName) {
+    if (hasUncommittedChanges(cwd)) throw new UncommittedChangesError(branchName)
+    return { branch: branchName, created: false }
+  }
+
+  if (hasUncommittedChanges(cwd)) throw new UncommittedChangesError(current || "(detached)")
+
+  try { git(["fetch", "origin"], cwd) } catch { /* best effort */ }
+
+  try {
+    git(["rev-parse", "--verify", `origin/${branchName}`], cwd)
+    git(["checkout", branchName], cwd)
+    try { git(["pull", "origin", branchName], cwd) } catch { /* best effort */ }
+    return { branch: branchName, created: false }
+  } catch { /* not on remote */ }
+
+  try {
+    git(["rev-parse", "--verify", branchName], cwd)
+    git(["checkout", branchName], cwd)
+    return { branch: branchName, created: false }
+  } catch { /* not local either */ }
+
+  try {
+    git(["checkout", "-b", branchName, `origin/${defaultBranch}`], cwd)
+  } catch {
+    git(["checkout", "-b", branchName], cwd)
+  }
+  return { branch: branchName, created: true }
+}

--- a/src-v2/branch.ts
+++ b/src-v2/branch.ts
@@ -38,7 +38,7 @@ export function getCurrentBranch(cwd?: string): string {
 }
 
 export function hasUncommittedChanges(cwd?: string): boolean {
-  return git(["status", "--porcelain"], cwd).length > 0
+  return git(["status", "--porcelain", "--untracked-files=no"], cwd).length > 0
 }
 
 export function ensureFeatureBranch(

--- a/src-v2/commit.ts
+++ b/src-v2/commit.ts
@@ -96,9 +96,17 @@ export function isForbiddenPath(p: string): boolean {
 }
 
 export function listChangedFiles(cwd?: string): string[] {
-  const status = git(["status", "--porcelain"], cwd)
-  if (!status) return []
-  return status.split("\n").map((line) => line.slice(3).trim()).filter(Boolean)
+  // Use NUL-delimited output to avoid quoting/whitespace issues with paths.
+  // Each entry begins with a 2-char status code + 1 space, then the path.
+  const raw = execFileSync("git", ["status", "--porcelain=v1", "-z"], {
+    encoding: "utf-8",
+    cwd,
+    env: { ...process.env, HUSKY: "0", SKIP_HOOKS: "1" },
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+  if (!raw) return []
+  const entries = raw.split("\0").filter((e) => e.length > 0)
+  return entries.map((e) => e.slice(3)).filter(Boolean)
 }
 
 export function normalizeCommitMessage(raw: string): string {

--- a/src-v2/commit.ts
+++ b/src-v2/commit.ts
@@ -24,13 +24,22 @@ export interface CommitResult {
 }
 
 function git(args: string[], cwd?: string): string {
-  return execFileSync("git", args, {
-    encoding: "utf-8",
-    timeout: 120_000,
-    cwd,
-    env: { ...process.env, HUSKY: "0", SKIP_HOOKS: "1" },
-    stdio: ["pipe", "pipe", "pipe"],
-  }).trim()
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf-8",
+      timeout: 120_000,
+      cwd,
+      env: { ...process.env, HUSKY: "0", SKIP_HOOKS: "1" },
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim()
+  } catch (err: unknown) {
+    const e = err as { stderr?: Buffer | string; stdout?: Buffer | string; status?: number; message?: string }
+    const stderr = e.stderr?.toString().trim() ?? ""
+    const stdout = e.stdout?.toString().trim() ?? ""
+    const status = e.status ?? "?"
+    const detail = stderr || stdout || e.message || "(no output)"
+    throw new Error(`git ${args.join(" ")} (exit ${status}):\n${detail}`)
+  }
 }
 
 function tryGit(args: string[], cwd?: string): boolean {

--- a/src-v2/commit.ts
+++ b/src-v2/commit.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from "child_process"
+
+const FORBIDDEN_PATH_PREFIXES = [
+  ".kody/",
+  ".kody-engine/",
+  ".kody-lean/",
+  "node_modules/",
+  "dist/",
+  "build/",
+]
+
+const FORBIDDEN_PATH_EXACT = new Set([".env"])
+const FORBIDDEN_PATH_SUFFIXES = [".log"]
+
+const CONVENTIONAL_PREFIXES = [
+  "feat:", "fix:", "chore:", "docs:", "refactor:", "test:", "perf:", "ci:", "style:", "build:", "revert:",
+]
+
+export interface CommitResult {
+  committed: boolean
+  pushed: boolean
+  sha: string
+  message: string
+}
+
+function git(args: string[], cwd?: string): string {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    timeout: 120_000,
+    cwd,
+    env: { ...process.env, HUSKY: "0", SKIP_HOOKS: "1" },
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim()
+}
+
+export function isForbiddenPath(p: string): boolean {
+  if (FORBIDDEN_PATH_EXACT.has(p)) return true
+  for (const pre of FORBIDDEN_PATH_PREFIXES) if (p.startsWith(pre)) return true
+  for (const suf of FORBIDDEN_PATH_SUFFIXES) if (p.endsWith(suf)) return true
+  return false
+}
+
+export function listChangedFiles(cwd?: string): string[] {
+  const status = git(["status", "--porcelain"], cwd)
+  if (!status) return []
+  return status.split("\n").map((line) => line.slice(3).trim()).filter(Boolean)
+}
+
+export function normalizeCommitMessage(raw: string): string {
+  const trimmed = raw.trim().replace(/^['"]|['"]$/g, "").trim()
+  if (!trimmed) return "chore: kody-lean update"
+  const firstLine = trimmed.split("\n")[0]
+  for (const prefix of CONVENTIONAL_PREFIXES) {
+    if (firstLine.toLowerCase().startsWith(prefix)) return trimmed
+  }
+  return `chore: ${trimmed}`
+}
+
+export function commitAndPush(
+  branch: string,
+  agentMessage: string,
+  cwd?: string,
+): CommitResult {
+  const allChanged = listChangedFiles(cwd)
+  const allowedFiles = allChanged.filter((f) => !isForbiddenPath(f))
+
+  if (allowedFiles.length === 0) {
+    return { committed: false, pushed: false, sha: "", message: "" }
+  }
+
+  for (const f of allowedFiles) {
+    try { git(["add", "--", f], cwd) } catch { /* skip individual file errors */ }
+  }
+
+  const message = normalizeCommitMessage(agentMessage)
+  try {
+    git(["commit", "--no-gpg-sign", "-m", message], cwd)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (/nothing to commit/i.test(msg)) {
+      return { committed: false, pushed: false, sha: "", message }
+    }
+    throw err
+  }
+
+  const sha = git(["rev-parse", "HEAD"], cwd).slice(0, 7)
+
+  try {
+    git(["push", "-u", "origin", branch], cwd)
+  } catch {
+    git(["push", "--force-with-lease", "-u", "origin", branch], cwd)
+  }
+
+  return { committed: true, pushed: true, sha, message }
+}
+
+export function hasCommitsAhead(branch: string, defaultBranch: string, cwd?: string): boolean {
+  try {
+    const out = git(["rev-list", "--count", `origin/${defaultBranch}..${branch}`], cwd)
+    return parseInt(out, 10) > 0
+  } catch {
+    try {
+      const out = git(["rev-list", "--count", `${defaultBranch}..${branch}`], cwd)
+      return parseInt(out, 10) > 0
+    } catch {
+      return false
+    }
+  }
+}

--- a/src-v2/commit.ts
+++ b/src-v2/commit.ts
@@ -33,6 +33,52 @@ function git(args: string[], cwd?: string): string {
   }).trim()
 }
 
+function tryGit(args: string[], cwd?: string): boolean {
+  try { git(args, cwd); return true } catch { return false }
+}
+
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * Real-world models sometimes run `git stash`, `git checkout`, `git merge`, etc.
+ * during their verification (despite prompt rules). When that leaves the repo
+ * in an unfinished state, our subsequent `git commit` fails. Clean up the
+ * common cases before staging.
+ */
+export function abortUnfinishedGitOps(cwd?: string): string[] {
+  const aborted: string[] = []
+  const gitDir = path.join(cwd ?? process.cwd(), ".git")
+  if (!fs.existsSync(gitDir)) return aborted
+
+  if (fs.existsSync(path.join(gitDir, "MERGE_HEAD"))) {
+    if (tryGit(["merge", "--abort"], cwd)) aborted.push("merge")
+  }
+  if (fs.existsSync(path.join(gitDir, "CHERRY_PICK_HEAD"))) {
+    if (tryGit(["cherry-pick", "--abort"], cwd)) aborted.push("cherry-pick")
+  }
+  if (fs.existsSync(path.join(gitDir, "REVERT_HEAD"))) {
+    if (tryGit(["revert", "--abort"], cwd)) aborted.push("revert")
+  }
+  if (
+    fs.existsSync(path.join(gitDir, "rebase-merge")) ||
+    fs.existsSync(path.join(gitDir, "rebase-apply"))
+  ) {
+    if (tryGit(["rebase", "--abort"], cwd)) aborted.push("rebase")
+  }
+
+  // Detect unmerged paths even without a sentinel file (rare).
+  try {
+    const unmerged = git(["diff", "--name-only", "--diff-filter=U"], cwd)
+    if (unmerged) {
+      tryGit(["reset", "--mixed", "HEAD"], cwd)
+      aborted.push("unmerged-paths-reset")
+    }
+  } catch { /* best effort */ }
+
+  return aborted
+}
+
 export function isForbiddenPath(p: string): boolean {
   if (FORBIDDEN_PATH_EXACT.has(p)) return true
   for (const pre of FORBIDDEN_PATH_PREFIXES) if (p.startsWith(pre)) return true
@@ -61,6 +107,11 @@ export function commitAndPush(
   agentMessage: string,
   cwd?: string,
 ): CommitResult {
+  const aborted = abortUnfinishedGitOps(cwd)
+  if (aborted.length > 0) {
+    process.stderr.write(`[kody-lean] cleaned up unfinished git ops: ${aborted.join(", ")}\n`)
+  }
+
   const allChanged = listChangedFiles(cwd)
   const allowedFiles = allChanged.filter((f) => !isForbiddenPath(f))
 

--- a/src-v2/config.ts
+++ b/src-v2/config.ts
@@ -1,0 +1,96 @@
+import * as fs from "fs"
+import * as path from "path"
+
+export interface KodyLeanConfig {
+  quality: {
+    typecheck: string
+    lint: string
+    testUnit: string
+  }
+  git: {
+    defaultBranch: string
+  }
+  github: {
+    owner: string
+    repo: string
+  }
+  agent: {
+    model: string
+  }
+}
+
+export interface ProviderModel {
+  provider: string
+  model: string
+}
+
+export const LITELLM_DEFAULT_PORT = 4000
+export const LITELLM_DEFAULT_URL = `http://localhost:${LITELLM_DEFAULT_PORT}`
+
+export function parseProviderModel(s: string): ProviderModel {
+  const slash = s.indexOf("/")
+  if (slash <= 0 || slash === s.length - 1) {
+    throw new Error(
+      `Invalid model spec '${s}' — expected 'provider/model' (e.g. 'minimax/MiniMax-M2.7-highspeed')`,
+    )
+  }
+  return { provider: s.slice(0, slash), model: s.slice(slash + 1) }
+}
+
+export function providerApiKeyEnvVar(provider: string): string {
+  if (provider === "anthropic" || provider === "claude") return "ANTHROPIC_API_KEY"
+  return `${provider.toUpperCase()}_API_KEY`
+}
+
+export function needsLitellmProxy(model: ProviderModel): boolean {
+  return model.provider !== "claude" && model.provider !== "anthropic"
+}
+
+export function loadConfig(projectDir: string = process.cwd()): KodyLeanConfig {
+  const configPath = path.join(projectDir, "kody.config.json")
+  if (!fs.existsSync(configPath)) {
+    throw new Error(`kody.config.json not found at ${configPath}`)
+  }
+
+  let raw: Record<string, any>
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf-8"))
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`kody.config.json is invalid JSON: ${msg}`)
+  }
+
+  const quality = raw.quality ?? {}
+  const git = raw.git ?? {}
+  const github = raw.github ?? {}
+  const agent = raw.agent ?? {}
+
+  if (!agent.model || typeof agent.model !== "string") {
+    throw new Error(`kody.config.json: agent.model is required (e.g. "minimax/MiniMax-M2.7-highspeed")`)
+  }
+  if (!github.owner || !github.repo) {
+    throw new Error(`kody.config.json: github.owner and github.repo are required`)
+  }
+
+  return {
+    quality: {
+      typecheck: typeof quality.typecheck === "string" ? quality.typecheck : "",
+      lint: typeof quality.lint === "string" ? quality.lint : "",
+      testUnit: typeof quality.testUnit === "string" ? quality.testUnit : "",
+    },
+    git: {
+      defaultBranch: typeof git.defaultBranch === "string" ? git.defaultBranch : "main",
+    },
+    github: {
+      owner: String(github.owner),
+      repo: String(github.repo),
+    },
+    agent: {
+      model: String(agent.model),
+    },
+  }
+}
+
+export function getAnthropicApiKeyOrDummy(): string {
+  return process.env.ANTHROPIC_API_KEY || `sk-ant-api03-${"0".repeat(64)}`
+}

--- a/src-v2/entry.ts
+++ b/src-v2/entry.ts
@@ -1,0 +1,106 @@
+import { run } from "./index.js"
+
+interface ParsedArgs {
+  command: "run" | "help" | "version"
+  issueNumber?: number
+  cwd?: string
+  verbose?: boolean
+  quiet?: boolean
+  dryRun?: boolean
+  errors: string[]
+}
+
+const HELP_TEXT = `kody-lean — single-session autonomous engineer (kody2)
+
+Usage:
+  kody-lean run --issue <N> [--cwd <path>] [--verbose|--quiet] [--dry-run]
+  kody-lean help
+  kody-lean version
+
+Options:
+  --issue <N>      GitHub issue number to work on (required)
+  --cwd <path>     Project directory (default: cwd)
+  --verbose        Print full tool output
+  --quiet          Print only errors and final PR_URL
+  --dry-run        Build branch + prompt + post start comment, then exit (no agent)
+
+Exit codes:
+  0  success (PR opened, verify passed)
+  1  agent reported FAILED (draft PR opened)
+  2  verify failed (draft PR opened)
+  3  no commits to ship
+  4  PR creation failed
+  5  uncommitted changes on target branch
+  99 wrapper crashed
+`
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const result: ParsedArgs = { command: "help", errors: [] }
+  if (argv.length === 0) return result
+
+  const cmd = argv[0]!
+  if (cmd === "help" || cmd === "--help" || cmd === "-h") return { ...result, command: "help" }
+  if (cmd === "version" || cmd === "--version" || cmd === "-v") return { ...result, command: "version" }
+  if (cmd !== "run") {
+    result.errors.push(`unknown command: ${cmd}`)
+    return result
+  }
+
+  result.command = "run"
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === "--issue") {
+      const n = parseInt(argv[++i] ?? "", 10)
+      if (Number.isNaN(n) || n <= 0) result.errors.push("--issue requires a positive integer")
+      else result.issueNumber = n
+    } else if (arg === "--cwd") {
+      result.cwd = argv[++i]
+    } else if (arg === "--verbose") {
+      result.verbose = true
+    } else if (arg === "--quiet") {
+      result.quiet = true
+    } else if (arg === "--dry-run") {
+      result.dryRun = true
+    } else {
+      result.errors.push(`unknown arg: ${arg}`)
+    }
+  }
+
+  if (!result.issueNumber) result.errors.push("--issue <N> is required")
+  return result
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const args = parseArgs(argv)
+
+  if (args.errors.length > 0) {
+    for (const e of args.errors) process.stderr.write(`error: ${e}\n`)
+    process.stderr.write("\n" + HELP_TEXT)
+    return 64
+  }
+  if (args.command === "help") {
+    process.stdout.write(HELP_TEXT)
+    return 0
+  }
+  if (args.command === "version") {
+    process.stdout.write("kody-lean 0.1.0\n")
+    return 0
+  }
+
+  try {
+    const result = await run({
+      issueNumber: args.issueNumber!,
+      cwd: args.cwd,
+      verbose: args.verbose,
+      quiet: args.quiet,
+      dryRun: args.dryRun,
+    })
+    return result.exitCode
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`[kody-lean] wrapper crashed: ${msg}\n`)
+    if (err instanceof Error && err.stack) process.stderr.write(err.stack + "\n")
+    process.stdout.write(`PR_URL=FAILED: wrapper crashed: ${msg}\n`)
+    return 99
+  }
+}

--- a/src-v2/format.ts
+++ b/src-v2/format.ts
@@ -1,0 +1,127 @@
+export interface SdkMessageLike {
+  type: string
+  subtype?: string
+  result?: unknown
+  message?: {
+    content?: Array<
+      | { type: "text"; text: string }
+      | { type: "tool_use"; name: string; input?: Record<string, unknown> }
+      | { type: "tool_result"; content?: unknown; is_error?: boolean }
+      | { type: string; [key: string]: unknown }
+    >
+  }
+  duration_ms?: number
+  duration_api_ms?: number
+  total_cost_usd?: number
+  num_turns?: number
+}
+
+export interface RenderOptions {
+  verbose?: boolean
+  quiet?: boolean
+}
+
+export function renderEvent(msg: SdkMessageLike, opts: RenderOptions = {}): string | null {
+  if (opts.quiet) {
+    if (msg.type === "result") return formatResult(msg)
+    return null
+  }
+
+  switch (msg.type) {
+    case "system":
+      return null
+    case "assistant":
+      return formatAssistant(msg, opts)
+    case "user":
+      return formatUserToolResult(msg, opts)
+    case "result":
+      return formatResult(msg)
+    default:
+      return null
+  }
+}
+
+function formatAssistant(msg: SdkMessageLike, opts: RenderOptions): string | null {
+  const content = msg.message?.content ?? []
+  const lines: string[] = []
+  for (const block of content) {
+    if (block.type === "text") {
+      const text = (block as { text: string }).text.trim()
+      if (text) lines.push(text)
+    } else if (block.type === "tool_use") {
+      const tu = block as { name: string; input?: Record<string, unknown> }
+      lines.push(`→ ${tu.name}${summarizeToolInput(tu.name, tu.input)}`)
+    }
+  }
+  return lines.length > 0 ? lines.join("\n") : null
+}
+
+function formatUserToolResult(msg: SdkMessageLike, opts: RenderOptions): string | null {
+  const content = msg.message?.content ?? []
+  const lines: string[] = []
+  for (const block of content) {
+    if (block.type === "tool_result") {
+      const tr = block as { content?: unknown; is_error?: boolean }
+      const text = stringifyToolContent(tr.content)
+      const lineCount = text.split("\n").length
+      const sizeBytes = text.length
+      const flag = tr.is_error ? " ERROR" : ""
+      const summary = `  ↳${flag} ${lineCount} lines, ${formatBytes(sizeBytes)}`
+      if (opts.verbose) {
+        lines.push(`${summary}\n${truncate(text, 4000)}`)
+      } else {
+        lines.push(summary)
+      }
+    }
+  }
+  return lines.length > 0 ? lines.join("\n") : null
+}
+
+function formatResult(msg: SdkMessageLike): string {
+  const ok = msg.subtype === "success"
+  const tag = ok ? "DONE" : `FAILED (${msg.subtype ?? "unknown"})`
+  const dur = msg.duration_ms ? ` ${(msg.duration_ms / 1000).toFixed(1)}s` : ""
+  const turns = msg.num_turns ? ` ${msg.num_turns} turns` : ""
+  const cost = typeof msg.total_cost_usd === "number" ? ` $${msg.total_cost_usd.toFixed(4)}` : ""
+  return `\n=== ${tag}${dur}${turns}${cost} ===`
+}
+
+function summarizeToolInput(toolName: string, input: Record<string, unknown> = {}): string {
+  if (toolName === "Bash" && typeof input.command === "string") {
+    const cmd = input.command.split("\n")[0]
+    return `: ${truncate(cmd, 120)}`
+  }
+  if ((toolName === "Read" || toolName === "Edit" || toolName === "Write") && typeof input.file_path === "string") {
+    return ` ${input.file_path}`
+  }
+  if ((toolName === "Glob" || toolName === "Grep") && typeof input.pattern === "string") {
+    return `: ${truncate(input.pattern, 80)}`
+  }
+  return ""
+}
+
+function stringifyToolContent(content: unknown): string {
+  if (typeof content === "string") return content
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => {
+        if (b && typeof b === "object" && "text" in b && typeof (b as { text: unknown }).text === "string") {
+          return (b as { text: string }).text
+        }
+        return JSON.stringify(b)
+      })
+      .join("\n")
+  }
+  return JSON.stringify(content)
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max) + `… (+${s.length - max} chars)`
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`
+}

--- a/src-v2/index.ts
+++ b/src-v2/index.ts
@@ -1,0 +1,238 @@
+import * as path from "path"
+import { loadConfig, parseProviderModel } from "./config.js"
+import { startLitellmIfNeeded } from "./litellm.js"
+import { ensureFeatureBranch, UncommittedChangesError } from "./branch.js"
+import { commitAndPush, hasCommitsAhead, listChangedFiles, isForbiddenPath } from "./commit.js"
+import { ensurePr } from "./pr.js"
+import { verifyAll, summarizeFailure } from "./verify.js"
+import { getIssue, postIssueComment, truncate } from "./issue.js"
+import { buildPrompt, parseAgentResult } from "./prompt.js"
+import { runAgent } from "./agent.js"
+
+export interface RunOptions {
+  issueNumber: number
+  cwd?: string
+  verbose?: boolean
+  quiet?: boolean
+  dryRun?: boolean
+}
+
+export interface RunResult {
+  exitCode: number
+  prUrl?: string
+  reason?: string
+}
+
+const RUN_URL = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+  : ""
+
+export async function run(opts: RunOptions): Promise<RunResult> {
+  const cwd = opts.cwd ?? process.cwd()
+  const issueNumber = opts.issueNumber
+
+  let config: ReturnType<typeof loadConfig>
+  try {
+    config = loadConfig(cwd)
+  } catch (err) {
+    return finish({ exitCode: 99, reason: `config error: ${errMsg(err)}` })
+  }
+
+  let issue
+  try {
+    issue = getIssue(issueNumber, cwd)
+  } catch (err) {
+    return finish({ exitCode: 99, reason: `failed to fetch issue #${issueNumber}: ${errMsg(err)}` })
+  }
+
+  let branchInfo
+  try {
+    branchInfo = ensureFeatureBranch(issueNumber, issue.title, config.git.defaultBranch, cwd)
+  } catch (err) {
+    if (err instanceof UncommittedChangesError) {
+      const reason = err.message
+      tryPost(issueNumber, `⚠️ kody2 refused to start: ${reason}`, cwd)
+      return finish({ exitCode: 5, reason })
+    }
+    return finish({ exitCode: 99, reason: `branch setup failed: ${errMsg(err)}` })
+  }
+
+  const startMsg = RUN_URL
+    ? `⚙️ kody2 started — branch \`${branchInfo.branch}\`, run ${RUN_URL}`
+    : `⚙️ kody2 started — branch \`${branchInfo.branch}\``
+  tryPost(issueNumber, startMsg, cwd)
+
+  if (opts.dryRun) {
+    return finish({ exitCode: 0, reason: "dry-run: prompt assembled, agent skipped" })
+  }
+
+  let model
+  try {
+    model = parseProviderModel(config.agent.model)
+  } catch (err) {
+    return finishWithDraftPr({
+      cwd,
+      branch: branchInfo.branch,
+      defaultBranch: config.git.defaultBranch,
+      issueNumber,
+      issueTitle: issue.title,
+      reason: `agent.model invalid: ${errMsg(err)}`,
+      exitCode: 99,
+    })
+  }
+
+  let litellm
+  try {
+    litellm = await startLitellmIfNeeded(model, cwd)
+  } catch (err) {
+    return finishWithDraftPr({
+      cwd,
+      branch: branchInfo.branch,
+      defaultBranch: config.git.defaultBranch,
+      issueNumber,
+      issueTitle: issue.title,
+      reason: `litellm startup failed: ${errMsg(err)}`,
+      exitCode: 99,
+    })
+  }
+
+  const prompt = buildPrompt({ config, issue, featureBranch: branchInfo.branch })
+
+  const ndjsonDir = path.join(cwd, ".kody-lean")
+  let agentResult
+  try {
+    agentResult = await runAgent({
+      prompt,
+      model,
+      cwd,
+      litellmUrl: litellm?.url ?? null,
+      verbose: opts.verbose,
+      quiet: opts.quiet,
+      ndjsonDir,
+    })
+  } finally {
+    try { litellm?.kill() } catch { /* best effort */ }
+  }
+
+  const parsed = parseAgentResult(agentResult.finalText)
+  const agentOk = agentResult.outcome === "completed" && parsed.done
+
+  let verifyOk = false
+  let verifyReason = ""
+  try {
+    const v = await verifyAll(config, cwd)
+    verifyOk = v.ok
+    if (!v.ok) verifyReason = summarizeFailure(v)
+  } catch (err) {
+    verifyReason = `verify crashed: ${errMsg(err)}`
+  }
+
+  let commitResult
+  try {
+    commitResult = commitAndPush(branchInfo.branch, parsed.commitMessage || `chore: kody2 changes for #${issueNumber}`, cwd)
+  } catch (err) {
+    return finishWithDraftPr({
+      cwd,
+      branch: branchInfo.branch,
+      defaultBranch: config.git.defaultBranch,
+      issueNumber,
+      issueTitle: issue.title,
+      reason: `commit/push failed: ${errMsg(err)}`,
+      exitCode: 4,
+    })
+  }
+
+  const ahead = hasCommitsAhead(branchInfo.branch, config.git.defaultBranch, cwd)
+  if (!commitResult.committed && !ahead) {
+    const reason = "no changes to commit"
+    tryPost(issueNumber, `⚠️ kody2 FAILED: ${reason}`, cwd)
+    return finish({ exitCode: 3, reason })
+  }
+
+  const failureReason = !agentOk
+    ? (parsed.failureReason || agentResult.error || "agent did not emit DONE")
+    : !verifyOk
+      ? verifyReason
+      : ""
+
+  const isFailure = failureReason !== ""
+  const changedFiles = listChangedFiles(cwd).filter((f) => !isForbiddenPath(f))
+
+  let prResult
+  try {
+    prResult = ensurePr({
+      branch: branchInfo.branch,
+      defaultBranch: config.git.defaultBranch,
+      issueNumber,
+      issueTitle: issue.title,
+      draft: isFailure,
+      failureReason: failureReason || undefined,
+      changedFiles,
+      cwd,
+    })
+  } catch (err) {
+    const reason = `PR creation failed: ${errMsg(err)}`
+    tryPost(issueNumber, `⚠️ kody2 FAILED: ${reason}`, cwd)
+    return finish({ exitCode: 4, reason })
+  }
+
+  const successMsg = isFailure
+    ? `⚠️ kody2 FAILED: ${truncate(failureReason, 1500)} — draft PR: ${prResult.url}`
+    : `✅ kody2 PR opened: ${prResult.url}`
+  tryPost(issueNumber, successMsg, cwd)
+
+  let exitCode = 0
+  if (!agentOk) exitCode = 1
+  else if (!verifyOk) exitCode = 2
+  return finish({ exitCode, prUrl: prResult.url, reason: failureReason || undefined })
+}
+
+function finish(r: RunResult): RunResult {
+  if (r.prUrl) process.stdout.write(`PR_URL=${r.prUrl}\n`)
+  else if (r.reason) process.stdout.write(`PR_URL=FAILED: ${r.reason}\n`)
+  return r
+}
+
+interface DraftPrInputs {
+  cwd: string
+  branch: string
+  defaultBranch: string
+  issueNumber: number
+  issueTitle: string
+  reason: string
+  exitCode: number
+}
+
+function finishWithDraftPr(inputs: DraftPrInputs): RunResult {
+  let prUrl: string | undefined
+  try {
+    const ahead = hasCommitsAhead(inputs.branch, inputs.defaultBranch, inputs.cwd)
+    if (ahead) {
+      const result = ensurePr({
+        branch: inputs.branch,
+        defaultBranch: inputs.defaultBranch,
+        issueNumber: inputs.issueNumber,
+        issueTitle: inputs.issueTitle,
+        draft: true,
+        failureReason: inputs.reason,
+        changedFiles: [],
+        cwd: inputs.cwd,
+      })
+      prUrl = result.url
+    }
+  } catch { /* best effort */ }
+
+  const msg = prUrl
+    ? `⚠️ kody2 FAILED: ${truncate(inputs.reason, 1500)} — draft PR: ${prUrl}`
+    : `⚠️ kody2 FAILED: ${truncate(inputs.reason, 1500)}`
+  tryPost(inputs.issueNumber, msg, inputs.cwd)
+  return finish({ exitCode: inputs.exitCode, prUrl, reason: inputs.reason })
+}
+
+function tryPost(issueNumber: number, body: string, cwd?: string): void {
+  try { postIssueComment(issueNumber, body, cwd) } catch { /* best effort */ }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src-v2/issue.ts
+++ b/src-v2/issue.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from "child_process"
+
+const API_TIMEOUT_MS = 30_000
+
+export interface IssueComment {
+  body: string
+  author: string
+  createdAt: string
+}
+
+export interface IssueData {
+  number: number
+  title: string
+  body: string
+  comments: IssueComment[]
+}
+
+function ghToken(): string | undefined {
+  return process.env.GH_PAT?.trim() || process.env.GH_TOKEN
+}
+
+export function gh(args: string[], options?: { input?: string; cwd?: string }): string {
+  const token = ghToken()
+  const env: NodeJS.ProcessEnv = token ? { ...process.env, GH_TOKEN: token } : { ...process.env }
+  return execFileSync("gh", args, {
+    encoding: "utf-8",
+    timeout: API_TIMEOUT_MS,
+    cwd: options?.cwd,
+    env,
+    input: options?.input,
+    stdio: options?.input ? ["pipe", "pipe", "pipe"] : ["inherit", "pipe", "pipe"],
+  }).trim()
+}
+
+export function getIssue(issueNumber: number, cwd?: string): IssueData {
+  const output = gh(
+    ["issue", "view", String(issueNumber), "--json", "number,title,body,comments"],
+    { cwd },
+  )
+  const parsed = JSON.parse(output)
+  if (typeof parsed?.title !== "string") {
+    throw new Error(`Issue #${issueNumber}: unexpected response shape`)
+  }
+  return {
+    number: parsed.number ?? issueNumber,
+    title: parsed.title,
+    body: parsed.body ?? "",
+    comments: (parsed.comments ?? []).map((c: { body: string; createdAt: string; author?: { login?: string } }) => ({
+      body: c.body ?? "",
+      author: c.author?.login ?? "unknown",
+      createdAt: c.createdAt ?? "",
+    })),
+  }
+}
+
+export function postIssueComment(issueNumber: number, body: string, cwd?: string): void {
+  try {
+    gh(
+      ["issue", "comment", String(issueNumber), "--body-file", "-"],
+      { input: body, cwd },
+    )
+  } catch (err) {
+    process.stderr.write(`[kody-lean] failed to post comment on #${issueNumber}: ${err instanceof Error ? err.message : String(err)}\n`)
+  }
+}
+
+export function truncate(s: string, maxBytes: number): string {
+  if (s.length <= maxBytes) return s
+  return s.slice(0, maxBytes) + `… (+${s.length - maxBytes} chars)`
+}

--- a/src-v2/litellm.ts
+++ b/src-v2/litellm.ts
@@ -1,0 +1,123 @@
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { execFileSync, spawn, type ChildProcess } from "child_process"
+import {
+  type ProviderModel,
+  providerApiKeyEnvVar,
+  needsLitellmProxy,
+  LITELLM_DEFAULT_URL,
+} from "./config.js"
+
+export async function checkLitellmHealth(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3000) })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+export function generateLitellmConfigYaml(model: ProviderModel): string {
+  const apiKeyVar = providerApiKeyEnvVar(model.provider)
+  return [
+    "model_list:",
+    `  - model_name: ${model.model}`,
+    `    litellm_params:`,
+    `      model: ${model.provider}/${model.model}`,
+    `      api_key: os.environ/${apiKeyVar}`,
+    "",
+    "litellm_settings:",
+    "  drop_params: true",
+    "",
+  ].join("\n")
+}
+
+export interface LitellmHandle {
+  url: string
+  kill: () => void
+}
+
+export async function startLitellmIfNeeded(
+  model: ProviderModel,
+  projectDir: string,
+  url: string = LITELLM_DEFAULT_URL,
+): Promise<LitellmHandle | null> {
+  if (!needsLitellmProxy(model)) return null
+
+  if (await checkLitellmHealth(url)) {
+    return { url, kill: () => {} }
+  }
+
+  let cmd = "litellm"
+  let args: string[]
+  try {
+    execFileSync("which", ["litellm"], { timeout: 3000, stdio: "pipe" })
+  } catch {
+    try {
+      execFileSync("python3", ["-c", "import litellm"], { timeout: 10000, stdio: "pipe" })
+      cmd = "python3"
+    } catch {
+      throw new Error("litellm not installed — run: pip install 'litellm[proxy]'")
+    }
+  }
+
+  const configPath = path.join(os.tmpdir(), `kody-lean-litellm-${Date.now()}.yaml`)
+  fs.writeFileSync(configPath, generateLitellmConfigYaml(model))
+
+  const portMatch = url.match(/:(\d+)/)
+  const port = portMatch ? portMatch[1] : "4000"
+  args = cmd === "litellm"
+    ? ["--config", configPath, "--port", port]
+    : ["-m", "litellm", "--config", configPath, "--port", port]
+
+  const dotenvVars = readDotenvApiKeys(projectDir)
+  const logPath = path.join(os.tmpdir(), `kody-lean-litellm-${Date.now()}.log`)
+  const outFd = fs.openSync(logPath, "w")
+
+  const child = spawn(cmd, args, {
+    stdio: ["ignore", outFd, outFd],
+    detached: true,
+    env: stripBlockingEnv({ ...process.env, ...dotenvVars }),
+  })
+  fs.closeSync(outFd)
+
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 2000))
+    if (await checkLitellmHealth(url)) {
+      return { url, kill: () => { try { child.kill() } catch { /* best effort */ } } }
+    }
+  }
+
+  let logTail = ""
+  try { logTail = fs.readFileSync(logPath, "utf-8").slice(-2000) } catch { /* ignore */ }
+  try { child.kill() } catch { /* ignore */ }
+  throw new Error(`LiteLLM proxy failed to start within 60s. Log tail:\n${logTail}`)
+}
+
+function readDotenvApiKeys(projectDir: string): Record<string, string> {
+  const dotenvPath = path.join(projectDir, ".env")
+  if (!fs.existsSync(dotenvPath)) return {}
+  const result: Record<string, string> = {}
+  for (const rawLine of fs.readFileSync(dotenvPath, "utf-8").split("\n")) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith("#")) continue
+    const match = line.match(/^([A-Z_][A-Z0-9_]*_API_KEY)=(.*)$/)
+    if (!match) continue
+    let value = match[2].trim()
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1)
+    }
+    const commentIdx = value.indexOf(" #")
+    if (commentIdx !== -1) value = value.slice(0, commentIdx).trim()
+    if (value) result[match[1]] = value
+  }
+  return result
+}
+
+function stripBlockingEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out = { ...env }
+  delete out.DATABASE_URL
+  delete out.AI_BASE_URL
+  return out
+}

--- a/src-v2/pr.ts
+++ b/src-v2/pr.ts
@@ -1,0 +1,100 @@
+import { gh, truncate } from "./issue.js"
+
+export interface PrResult {
+  url: string
+  number: number
+  draft: boolean
+  action: "created" | "updated"
+}
+
+export interface EnsurePrOptions {
+  branch: string
+  defaultBranch: string
+  issueNumber: number
+  issueTitle: string
+  draft: boolean
+  failureReason?: string
+  changedFiles: string[]
+  cwd?: string
+}
+
+const TITLE_MAX = 72
+
+export function buildPrTitle(issueNumber: number, issueTitle: string, draft: boolean): string {
+  const prefix = draft ? "[WIP] " : ""
+  const base = `${prefix}#${issueNumber}: ${issueTitle}`
+  if (base.length <= TITLE_MAX) return base
+  return base.slice(0, TITLE_MAX - 1) + "…"
+}
+
+export function buildPrBody(opts: EnsurePrOptions): string {
+  const lines: string[] = []
+  if (opts.draft && opts.failureReason) {
+    lines.push(`> ⚠️ FAILED: ${truncate(opts.failureReason, 2000)}`)
+    lines.push("")
+  }
+  lines.push("## Summary")
+  lines.push("")
+  lines.push(`Implementation of issue #${opts.issueNumber} — ${opts.issueTitle}`)
+  lines.push("")
+
+  if (opts.changedFiles.length > 0) {
+    lines.push("## Changes")
+    lines.push("")
+    for (const f of opts.changedFiles.slice(0, 50)) lines.push(`- \`${f}\``)
+    if (opts.changedFiles.length > 50) lines.push(`- … and ${opts.changedFiles.length - 50} more`)
+    lines.push("")
+  }
+
+  lines.push(`Closes #${opts.issueNumber}`)
+  lines.push("")
+  lines.push("---")
+  lines.push("_Opened by kody-lean (single-session autonomous run)._ ")
+  return lines.join("\n")
+}
+
+export function findExistingPr(branch: string, cwd?: string): { number: number; url: string } | null {
+  try {
+    const output = gh(["pr", "view", branch, "--json", "number,url"], { cwd })
+    const parsed = JSON.parse(output)
+    if (typeof parsed?.number === "number" && typeof parsed?.url === "string") {
+      return { number: parsed.number, url: parsed.url }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+export function ensurePr(opts: EnsurePrOptions): PrResult {
+  const title = buildPrTitle(opts.issueNumber, opts.issueTitle, opts.draft)
+  const body = buildPrBody(opts)
+
+  const existing = findExistingPr(opts.branch, opts.cwd)
+  if (existing) {
+    try {
+      gh(
+        ["pr", "edit", String(existing.number), "--title", title, "--body-file", "-"],
+        { input: body, cwd: opts.cwd },
+      )
+    } catch (err) {
+      process.stderr.write(`[kody-lean] failed to update PR #${existing.number}: ${err instanceof Error ? err.message : String(err)}\n`)
+    }
+    return { url: existing.url, number: existing.number, draft: opts.draft, action: "updated" }
+  }
+
+  const args = [
+    "pr", "create",
+    "--head", opts.branch,
+    "--base", opts.defaultBranch,
+    "--title", title,
+    "--body-file", "-",
+  ]
+  if (opts.draft) args.push("--draft")
+
+  const output = gh(args, { input: body, cwd: opts.cwd })
+  const url = output.trim()
+  const match = url.match(/\/pull\/(\d+)$/)
+  const number = match ? parseInt(match[1], 10) : 0
+  return { url, number, draft: opts.draft, action: "created" }
+}

--- a/src-v2/prompt.ts
+++ b/src-v2/prompt.ts
@@ -1,0 +1,94 @@
+import type { KodyLeanConfig } from "./config.js"
+import type { IssueData, IssueComment } from "./issue.js"
+
+const COMMENT_MAX_BYTES = 4000
+const COMMENT_LIMIT = 5
+
+export interface BuildPromptOptions {
+  config: KodyLeanConfig
+  issue: IssueData
+  featureBranch: string
+}
+
+export function buildPrompt(opts: BuildPromptOptions): string {
+  const { config, issue, featureBranch } = opts
+  const qualityLines: string[] = []
+  if (config.quality.typecheck) qualityLines.push(`- typecheck: \`${config.quality.typecheck}\``)
+  if (config.quality.testUnit) qualityLines.push(`- tests:     \`${config.quality.testUnit}\``)
+  if (config.quality.lint) qualityLines.push(`- lint:      \`${config.quality.lint}\``)
+  if (qualityLines.length === 0) qualityLines.push("- (no quality commands configured)")
+
+  const commentsBlock = formatComments(issue.comments)
+
+  return `You are Kody, an autonomous engineer. Take a GitHub issue from spec to a tested set of edits in ONE session. The wrapper handles git/gh — you do not.
+
+# Repo
+- ${config.github.owner}/${config.github.repo}, default branch: ${config.git.defaultBranch}
+- current branch (already checked out): ${featureBranch}
+
+# Issue #${issue.number}: ${issue.title}
+${issue.body || "(no body)"}
+
+${commentsBlock}
+
+# Quality gates (MUST all pass)
+${qualityLines.join("\n")}
+
+# Required steps (all in this one session — no handoff)
+1. **Research** — read the issue carefully. Use Grep/Glob/Read to investigate the codebase: locate relevant files, understand existing patterns, check related tests, identify constraints. Do not edit anything yet.
+2. **Plan** — before any Edit/Write, output a short plan (5–10 lines): what files you'll change, the approach, what could go wrong. No fluff.
+3. **Build** — Edit/Write to implement the change. Stay within the plan; if you discover the plan was wrong, briefly say so and adjust.
+4. **Verify** — run each quality command with Bash. On failure, fix the root cause and re-run. When reporting that a command passed, you MUST have just run it and seen exit code 0 in this session — do not paraphrase prior output.
+5. Your FINAL message must be exactly two lines (or one line on failure):
+
+   DONE
+   COMMIT_MSG: <conventional-commit message, e.g. "feat: add X" or "fix: handle Y">
+
+   Or on failure: FAILED: <reason>
+
+# Rules
+- Do NOT run any \`git\` or \`gh\` commands — the wrapper handles all git ops, commits, pushes, PRs, and comments.
+- Stay on the current branch (\`${featureBranch}\`). It is already checked out for you.
+- Do NOT modify files under: \`.kody/\`, \`.kody-engine/\`, \`.kody-lean/\`, \`node_modules/\`, \`dist/\`, \`build/\`, \`.env\`, or any \`*.log\`.
+- Do NOT post issue comments — the wrapper handles that.
+- Keep the plan and reasoning concise. Long monologues waste turns.`
+}
+
+function formatComments(comments: IssueComment[]): string {
+  if (comments.length === 0) return "Recent comments: (none)"
+  const recent = comments.slice(-COMMENT_LIMIT).reverse()
+  const lines = ["Recent comments (most recent first, truncated):"]
+  for (const c of recent) {
+    const body = c.body.length > COMMENT_MAX_BYTES
+      ? c.body.slice(0, COMMENT_MAX_BYTES) + "… (truncated)"
+      : c.body
+    lines.push(`- [${c.author}] ${body.replace(/\n/g, " ")}`)
+  }
+  return lines.join("\n")
+}
+
+export interface ParsedAgentResult {
+  done: boolean
+  commitMessage: string
+  failureReason: string
+}
+
+export function parseAgentResult(finalText: string): ParsedAgentResult {
+  const text = (finalText || "").trim()
+  if (!text) return { done: false, commitMessage: "", failureReason: "agent produced no final message" }
+
+  const failedMatch = text.match(/(?:^|\n)\s*FAILED\s*:\s*(.+?)\s*$/s)
+  if (failedMatch) {
+    return { done: false, commitMessage: "", failureReason: failedMatch[1]!.trim() }
+  }
+
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+  const doneLine = lines.find((l) => /^DONE\b/i.test(l))
+  if (!doneLine) {
+    return { done: false, commitMessage: "", failureReason: "no DONE or FAILED marker in agent output" }
+  }
+
+  const commitLine = lines.find((l) => /^COMMIT_MSG\s*:/i.test(l))
+  const commitMessage = commitLine ? commitLine.replace(/^COMMIT_MSG\s*:\s*/i, "").trim() : ""
+  return { done: true, commitMessage, failureReason: "" }
+}

--- a/src-v2/prompt.ts
+++ b/src-v2/prompt.ts
@@ -47,10 +47,11 @@ ${qualityLines.join("\n")}
    Or on failure: FAILED: <reason>
 
 # Rules
-- Do NOT run any \`git\` or \`gh\` commands — the wrapper handles all git ops, commits, pushes, PRs, and comments.
+- Do NOT run **any** \`git\` or \`gh\` commands. Not for committing. Not for pushing. Not for inspecting state. Not for "verifying whether failures are pre-existing." Not stash, checkout, diff, status, log, branch — none. The wrapper handles all git/gh operations. If a quality gate fails, that's the failure — do not investigate it via git.
 - Stay on the current branch (\`${featureBranch}\`). It is already checked out for you.
 - Do NOT modify files under: \`.kody/\`, \`.kody-engine/\`, \`.kody-lean/\`, \`node_modules/\`, \`dist/\`, \`build/\`, \`.env\`, or any \`*.log\`.
 - Do NOT post issue comments — the wrapper handles that.
+- Pre-existing quality-gate failures: assume they are NOT your responsibility unless your edits touched related code. If quality gates are red but your edits are unrelated, output \`DONE\` with a COMMIT_MSG describing only what you actually changed.
 - Keep the plan and reasoning concise. Long monologues waste turns.`
 }
 

--- a/src-v2/verify.ts
+++ b/src-v2/verify.ts
@@ -1,0 +1,87 @@
+import { spawn } from "child_process"
+import type { KodyLeanConfig } from "./config.js"
+
+export interface VerifyResult {
+  ok: boolean
+  failed: string[]
+  details: Record<string, { exitCode: number; durationMs: number; tail: string }>
+}
+
+const TAIL_CHARS = 4000
+const COMMAND_TIMEOUT_MS = 10 * 60 * 1000
+
+interface RunResult {
+  exitCode: number
+  durationMs: number
+  tail: string
+}
+
+function runCommand(command: string, cwd?: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const child = spawn(command, {
+      cwd,
+      shell: true,
+      env: { ...process.env, HUSKY: "0", SKIP_HOOKS: "1", CI: process.env.CI ?? "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    const buffers: Buffer[] = []
+    let totalSize = 0
+    const collect = (chunk: Buffer): void => {
+      buffers.push(chunk)
+      totalSize += chunk.length
+      while (totalSize > TAIL_CHARS * 4 && buffers.length > 1) {
+        totalSize -= buffers[0]!.length
+        buffers.shift()
+      }
+    }
+
+    child.stdout?.on("data", collect)
+    child.stderr?.on("data", collect)
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM")
+      setTimeout(() => { if (!child.killed) child.kill("SIGKILL") }, 5000)
+    }, COMMAND_TIMEOUT_MS)
+
+    child.on("exit", (code) => {
+      clearTimeout(timer)
+      const tail = Buffer.concat(buffers).toString("utf-8").slice(-TAIL_CHARS)
+      resolve({ exitCode: code ?? -1, durationMs: Date.now() - start, tail })
+    })
+    child.on("error", (err) => {
+      clearTimeout(timer)
+      resolve({ exitCode: -1, durationMs: Date.now() - start, tail: err.message })
+    })
+  })
+}
+
+export async function verifyAll(config: KodyLeanConfig, cwd?: string): Promise<VerifyResult> {
+  const commands: { name: string; cmd: string }[] = []
+  if (config.quality.typecheck) commands.push({ name: "typecheck", cmd: config.quality.typecheck })
+  if (config.quality.testUnit) commands.push({ name: "test", cmd: config.quality.testUnit })
+  if (config.quality.lint) commands.push({ name: "lint", cmd: config.quality.lint })
+
+  const failed: string[] = []
+  const details: Record<string, RunResult> = {}
+
+  for (const { name, cmd } of commands) {
+    const result = await runCommand(cmd, cwd)
+    details[name] = result
+    if (result.exitCode !== 0) failed.push(name)
+  }
+
+  return { ok: failed.length === 0, failed, details }
+}
+
+export function summarizeFailure(result: VerifyResult): string {
+  const lines = [`verify failed: ${result.failed.join(", ")}`]
+  for (const name of result.failed) {
+    const d = result.details[name]
+    if (!d) continue
+    lines.push(`\n--- ${name} (exit ${d.exitCode}, ${(d.durationMs / 1000).toFixed(1)}s) ---`)
+    lines.push(d.tail)
+  }
+  return lines.join("\n")
+}

--- a/src-v2/verify.ts
+++ b/src-v2/verify.ts
@@ -75,13 +75,19 @@ export async function verifyAll(config: KodyLeanConfig, cwd?: string): Promise<V
   return { ok: failed.length === 0, failed, details }
 }
 
+const ANSI_RE = /\x1B\[[0-?]*[ -/]*[@-~]/g
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "")
+}
+
 export function summarizeFailure(result: VerifyResult): string {
   const lines = [`verify failed: ${result.failed.join(", ")}`]
   for (const name of result.failed) {
     const d = result.details[name]
     if (!d) continue
     lines.push(`\n--- ${name} (exit ${d.exitCode}, ${(d.durationMs / 1000).toFixed(1)}s) ---`)
-    lines.push(d.tail)
+    lines.push(stripAnsi(d.tail))
   }
   return lines.join("\n")
 }

--- a/tests/lean/int/git-flow.test.ts
+++ b/tests/lean/int/git-flow.test.ts
@@ -83,12 +83,19 @@ describe("integration: git flow", () => {
     expect(getCurrentBranch(repo.workdir)).toBe(second.branch)
   })
 
-  it("refuses to run on a branch with uncommitted changes", () => {
+  it("refuses to run on a branch with uncommitted changes to tracked files", () => {
     ensureFeatureBranch(8, "Y", "main", repo.workdir)
-    fs.writeFileSync(path.join(repo.workdir, "wip.txt"), "in progress")
+    fs.writeFileSync(path.join(repo.workdir, "README.md"), "# initial\nWIP edit\n")
     expect(hasUncommittedChanges(repo.workdir)).toBe(true)
     expect(() => ensureFeatureBranch(8, "Y", "main", repo.workdir))
       .toThrow(UncommittedChangesError)
+  })
+
+  it("ignores untracked files (not protectable WIP)", () => {
+    ensureFeatureBranch(81, "Z", "main", repo.workdir)
+    fs.writeFileSync(path.join(repo.workdir, "scratch.tmp"), "junk")
+    expect(hasUncommittedChanges(repo.workdir)).toBe(false)
+    expect(() => ensureFeatureBranch(81, "Z", "main", repo.workdir)).not.toThrow()
   })
 
   it("commits allowed files and pushes to remote", () => {

--- a/tests/lean/int/git-flow.test.ts
+++ b/tests/lean/int/git-flow.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { execFileSync } from "child_process"
+import {
+  ensureFeatureBranch,
+  deriveBranchName,
+  hasUncommittedChanges,
+  getCurrentBranch,
+  UncommittedChangesError,
+} from "../../../src-v2/branch.js"
+import {
+  commitAndPush,
+  hasCommitsAhead,
+  listChangedFiles,
+} from "../../../src-v2/commit.js"
+
+interface TempRepo {
+  workdir: string
+  remote: string
+  cleanup: () => void
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    cwd,
+    env: {
+      ...process.env,
+      HUSKY: "0",
+      SKIP_HOOKS: "1",
+      GIT_AUTHOR_NAME: "Kody Test",
+      GIT_AUTHOR_EMAIL: "test@kody",
+      GIT_COMMITTER_NAME: "Kody Test",
+      GIT_COMMITTER_EMAIL: "test@kody",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim()
+}
+
+function makeTempRepo(): TempRepo {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "kody-lean-int-"))
+  const remote = path.join(root, "remote.git")
+  const workdir = path.join(root, "work")
+  fs.mkdirSync(workdir, { recursive: true })
+
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", remote], { stdio: "pipe" })
+  execFileSync("git", ["init", "--initial-branch=main", workdir], { stdio: "pipe" })
+  git(workdir, ["remote", "add", "origin", remote])
+  fs.writeFileSync(path.join(workdir, "README.md"), "# initial\n")
+  git(workdir, ["add", "."])
+  git(workdir, ["commit", "--no-gpg-sign", "-m", "initial"])
+  git(workdir, ["push", "-u", "origin", "main"])
+
+  return {
+    workdir,
+    remote,
+    cleanup: () => {
+      try { fs.rmSync(root, { recursive: true, force: true }) } catch { /* best effort */ }
+    },
+  }
+}
+
+describe("integration: git flow", () => {
+  let repo: TempRepo
+
+  beforeEach(() => { repo = makeTempRepo() })
+  afterEach(() => { repo.cleanup() })
+
+  it("creates a feature branch from main", () => {
+    const result = ensureFeatureBranch(123, "Add cool thing", "main", repo.workdir)
+    expect(result.branch).toBe(deriveBranchName(123, "Add cool thing"))
+    expect(result.created).toBe(true)
+    expect(getCurrentBranch(repo.workdir)).toBe(result.branch)
+  })
+
+  it("re-enters existing feature branch idempotently", () => {
+    ensureFeatureBranch(7, "X", "main", repo.workdir)
+    git(repo.workdir, ["checkout", "main"])
+    const second = ensureFeatureBranch(7, "X", "main", repo.workdir)
+    expect(second.created).toBe(false)
+    expect(getCurrentBranch(repo.workdir)).toBe(second.branch)
+  })
+
+  it("refuses to run on a branch with uncommitted changes", () => {
+    ensureFeatureBranch(8, "Y", "main", repo.workdir)
+    fs.writeFileSync(path.join(repo.workdir, "wip.txt"), "in progress")
+    expect(hasUncommittedChanges(repo.workdir)).toBe(true)
+    expect(() => ensureFeatureBranch(8, "Y", "main", repo.workdir))
+      .toThrow(UncommittedChangesError)
+  })
+
+  it("commits allowed files and pushes to remote", () => {
+    const branch = ensureFeatureBranch(9, "Edit Z", "main", repo.workdir).branch
+    fs.writeFileSync(path.join(repo.workdir, "src.txt"), "content")
+    fs.mkdirSync(path.join(repo.workdir, "node_modules"), { recursive: true })
+    fs.writeFileSync(path.join(repo.workdir, "node_modules/x.txt"), "should be excluded")
+
+    expect(listChangedFiles(repo.workdir).length).toBeGreaterThan(0)
+
+    const result = commitAndPush(branch, "feat: add stuff", repo.workdir)
+    expect(result.committed).toBe(true)
+    expect(result.pushed).toBe(true)
+    expect(result.message).toBe("feat: add stuff")
+    expect(hasCommitsAhead(branch, "main", repo.workdir)).toBe(true)
+
+    const log = git(repo.workdir, ["log", "--oneline", "-1"])
+    expect(log).toMatch(/feat: add stuff/)
+
+    const trackedFiles = git(repo.workdir, ["ls-files"]).split("\n")
+    expect(trackedFiles).toContain("src.txt")
+    expect(trackedFiles.find((f) => f.startsWith("node_modules/"))).toBeUndefined()
+  })
+
+  it("normalizes commit prefix when missing", () => {
+    const branch = ensureFeatureBranch(10, "Edit W", "main", repo.workdir).branch
+    fs.writeFileSync(path.join(repo.workdir, "x.txt"), "y")
+    const result = commitAndPush(branch, "just an edit", repo.workdir)
+    expect(result.message.startsWith("chore: ")).toBe(true)
+  })
+
+  it("returns committed=false when only forbidden files changed", () => {
+    const branch = ensureFeatureBranch(11, "Only excluded", "main", repo.workdir).branch
+    fs.mkdirSync(path.join(repo.workdir, ".kody-lean"), { recursive: true })
+    fs.writeFileSync(path.join(repo.workdir, ".kody-lean/run.jsonl"), "x")
+    const result = commitAndPush(branch, "feat: bogus", repo.workdir)
+    expect(result.committed).toBe(false)
+    expect(hasCommitsAhead(branch, "main", repo.workdir)).toBe(false)
+  })
+})

--- a/tests/lean/unit/branch.test.ts
+++ b/tests/lean/unit/branch.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { deriveBranchName, UncommittedChangesError } from "../../../src-v2/branch.js"
+
+describe("branch: deriveBranchName", () => {
+  it("slugifies title with issue number prefix", () => {
+    expect(deriveBranchName(42, "Add feature X")).toBe("42-add-feature-x")
+  })
+
+  it("strips special characters", () => {
+    expect(deriveBranchName(7, "Fix: bug! (urgent)")).toBe("7-fix-bug-urgent")
+  })
+
+  it("collapses repeated dashes", () => {
+    expect(deriveBranchName(1, "a   b---c")).toBe("1-a-b-c")
+  })
+
+  it("trims trailing dash", () => {
+    expect(deriveBranchName(1, "feature-")).toBe("1-feature")
+  })
+
+  it("caps slug length to 50 chars", () => {
+    const long = "a".repeat(80)
+    const result = deriveBranchName(1, long)
+    expect(result.length).toBeLessThanOrEqual(53)
+    expect(result.startsWith("1-")).toBe(true)
+  })
+
+  it("handles empty title", () => {
+    expect(deriveBranchName(99, "")).toBe("99")
+  })
+
+  it("handles title that produces empty slug", () => {
+    expect(deriveBranchName(99, "!!!")).toBe("99")
+  })
+})
+
+describe("branch: UncommittedChangesError", () => {
+  it("includes branch name in message", () => {
+    const err = new UncommittedChangesError("feat-branch")
+    expect(err.message).toMatch(/feat-branch/)
+    expect(err.name).toBe("UncommittedChangesError")
+    expect(err.branch).toBe("feat-branch")
+  })
+})

--- a/tests/lean/unit/commit.test.ts
+++ b/tests/lean/unit/commit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest"
+import { isForbiddenPath, normalizeCommitMessage } from "../../../src-v2/commit.js"
+
+describe("commit: isForbiddenPath", () => {
+  it("blocks .kody/ artifacts", () => {
+    expect(isForbiddenPath(".kody/tasks/1/x.json")).toBe(true)
+    expect(isForbiddenPath(".kody-engine/event-log.json")).toBe(true)
+    expect(isForbiddenPath(".kody-lean/last-run.jsonl")).toBe(true)
+  })
+
+  it("blocks node_modules and build outputs", () => {
+    expect(isForbiddenPath("node_modules/foo/index.js")).toBe(true)
+    expect(isForbiddenPath("dist/cli.js")).toBe(true)
+    expect(isForbiddenPath("build/x")).toBe(true)
+  })
+
+  it("blocks .env exact and .log suffix", () => {
+    expect(isForbiddenPath(".env")).toBe(true)
+    expect(isForbiddenPath("debug.log")).toBe(true)
+    expect(isForbiddenPath("logs/x.log")).toBe(true)
+  })
+
+  it("allows source files", () => {
+    expect(isForbiddenPath("src/foo.ts")).toBe(false)
+    expect(isForbiddenPath("README.md")).toBe(false)
+    expect(isForbiddenPath("package.json")).toBe(false)
+  })
+
+  it("does not block .env.example", () => {
+    expect(isForbiddenPath(".env.example")).toBe(false)
+  })
+})
+
+describe("commit: normalizeCommitMessage", () => {
+  it("preserves messages with valid conventional prefix", () => {
+    expect(normalizeCommitMessage("feat: add X")).toBe("feat: add X")
+    expect(normalizeCommitMessage("fix: handle Y")).toBe("fix: handle Y")
+    expect(normalizeCommitMessage("chore: bump deps")).toBe("chore: bump deps")
+  })
+
+  it("prepends chore: when prefix missing", () => {
+    expect(normalizeCommitMessage("update readme")).toBe("chore: update readme")
+  })
+
+  it("strips surrounding quotes", () => {
+    expect(normalizeCommitMessage('"feat: x"')).toBe("feat: x")
+    expect(normalizeCommitMessage("'fix: y'")).toBe("fix: y")
+  })
+
+  it("handles empty input", () => {
+    expect(normalizeCommitMessage("")).toBe("chore: kody-lean update")
+    expect(normalizeCommitMessage("   ")).toBe("chore: kody-lean update")
+  })
+
+  it("recognizes prefix case-insensitively", () => {
+    expect(normalizeCommitMessage("Feat: add X")).toBe("Feat: add X")
+  })
+
+  it("checks only first line for prefix", () => {
+    const msg = "feat: add X\n\nLong body\nfix: not a prefix here"
+    expect(normalizeCommitMessage(msg)).toBe(msg)
+  })
+})

--- a/tests/lean/unit/config.test.ts
+++ b/tests/lean/unit/config.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import {
+  loadConfig,
+  parseProviderModel,
+  needsLitellmProxy,
+  providerApiKeyEnvVar,
+} from "../../../src-v2/config.js"
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "kody-lean-test-"))
+}
+
+function writeConfig(dir: string, contents: unknown): void {
+  fs.writeFileSync(path.join(dir, "kody.config.json"), JSON.stringify(contents))
+}
+
+describe("config: parseProviderModel", () => {
+  it("parses 'provider/model' correctly", () => {
+    expect(parseProviderModel("minimax/MiniMax-M2.7-highspeed")).toEqual({
+      provider: "minimax",
+      model: "MiniMax-M2.7-highspeed",
+    })
+  })
+
+  it("throws on missing slash", () => {
+    expect(() => parseProviderModel("badmodel")).toThrow(/Invalid model spec/)
+  })
+
+  it("throws on trailing slash", () => {
+    expect(() => parseProviderModel("provider/")).toThrow(/Invalid model spec/)
+  })
+
+  it("preserves slashes inside model name", () => {
+    expect(parseProviderModel("a/b/c")).toEqual({ provider: "a", model: "b/c" })
+  })
+})
+
+describe("config: needsLitellmProxy / providerApiKeyEnvVar", () => {
+  it("anthropic providers do not need proxy", () => {
+    expect(needsLitellmProxy({ provider: "claude", model: "x" })).toBe(false)
+    expect(needsLitellmProxy({ provider: "anthropic", model: "x" })).toBe(false)
+  })
+
+  it("other providers need proxy", () => {
+    expect(needsLitellmProxy({ provider: "minimax", model: "x" })).toBe(true)
+  })
+
+  it("derives env var name correctly", () => {
+    expect(providerApiKeyEnvVar("claude")).toBe("ANTHROPIC_API_KEY")
+    expect(providerApiKeyEnvVar("anthropic")).toBe("ANTHROPIC_API_KEY")
+    expect(providerApiKeyEnvVar("minimax")).toBe("MINIMAX_API_KEY")
+    expect(providerApiKeyEnvVar("openai")).toBe("OPENAI_API_KEY")
+  })
+})
+
+describe("config: loadConfig", () => {
+  it("loads minimal valid config", () => {
+    const dir = tmpDir()
+    writeConfig(dir, {
+      github: { owner: "o", repo: "r" },
+      agent: { model: "minimax/m" },
+    })
+    const cfg = loadConfig(dir)
+    expect(cfg.github.owner).toBe("o")
+    expect(cfg.agent.model).toBe("minimax/m")
+    expect(cfg.git.defaultBranch).toBe("main")
+  })
+
+  it("throws when kody.config.json missing", () => {
+    const dir = tmpDir()
+    expect(() => loadConfig(dir)).toThrow(/not found/)
+  })
+
+  it("throws on malformed JSON", () => {
+    const dir = tmpDir()
+    fs.writeFileSync(path.join(dir, "kody.config.json"), "{not json")
+    expect(() => loadConfig(dir)).toThrow(/invalid JSON/)
+  })
+
+  it("throws when agent.model missing", () => {
+    const dir = tmpDir()
+    writeConfig(dir, { github: { owner: "o", repo: "r" }, agent: {} })
+    expect(() => loadConfig(dir)).toThrow(/agent\.model/)
+  })
+
+  it("throws when github.owner missing", () => {
+    const dir = tmpDir()
+    writeConfig(dir, { github: { repo: "r" }, agent: { model: "m/x" } })
+    expect(() => loadConfig(dir)).toThrow(/github\.owner/)
+  })
+
+  it("preserves quality commands", () => {
+    const dir = tmpDir()
+    writeConfig(dir, {
+      github: { owner: "o", repo: "r" },
+      agent: { model: "m/x" },
+      quality: { typecheck: "tc", testUnit: "tu", lint: "ln" },
+    })
+    const cfg = loadConfig(dir)
+    expect(cfg.quality).toEqual({ typecheck: "tc", testUnit: "tu", lint: "ln" })
+  })
+})

--- a/tests/lean/unit/entry.test.ts
+++ b/tests/lean/unit/entry.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest"
+import { parseArgs } from "../../../src-v2/entry.js"
+
+describe("entry: parseArgs", () => {
+  it("returns help when no args", () => {
+    expect(parseArgs([]).command).toBe("help")
+  })
+
+  it("recognizes help variants", () => {
+    expect(parseArgs(["help"]).command).toBe("help")
+    expect(parseArgs(["--help"]).command).toBe("help")
+    expect(parseArgs(["-h"]).command).toBe("help")
+  })
+
+  it("recognizes version variants", () => {
+    expect(parseArgs(["version"]).command).toBe("version")
+    expect(parseArgs(["--version"]).command).toBe("version")
+    expect(parseArgs(["-v"]).command).toBe("version")
+  })
+
+  it("parses run --issue", () => {
+    const a = parseArgs(["run", "--issue", "42"])
+    expect(a.command).toBe("run")
+    expect(a.issueNumber).toBe(42)
+    expect(a.errors).toEqual([])
+  })
+
+  it("requires --issue for run", () => {
+    const a = parseArgs(["run"])
+    expect(a.command).toBe("run")
+    expect(a.errors.length).toBeGreaterThan(0)
+  })
+
+  it("rejects non-positive issue numbers", () => {
+    expect(parseArgs(["run", "--issue", "0"]).errors.length).toBeGreaterThan(0)
+    expect(parseArgs(["run", "--issue", "abc"]).errors.length).toBeGreaterThan(0)
+  })
+
+  it("parses verbose / quiet / dry-run flags", () => {
+    const a = parseArgs(["run", "--issue", "1", "--verbose", "--dry-run"])
+    expect(a.verbose).toBe(true)
+    expect(a.dryRun).toBe(true)
+  })
+
+  it("parses --cwd", () => {
+    const a = parseArgs(["run", "--issue", "1", "--cwd", "/tmp/foo"])
+    expect(a.cwd).toBe("/tmp/foo")
+  })
+
+  it("rejects unknown commands", () => {
+    expect(parseArgs(["frobnicate"]).errors.length).toBeGreaterThan(0)
+  })
+
+  it("rejects unknown flags", () => {
+    const a = parseArgs(["run", "--issue", "1", "--bogus"])
+    expect(a.errors.some((e) => e.includes("--bogus"))).toBe(true)
+  })
+})

--- a/tests/lean/unit/format.test.ts
+++ b/tests/lean/unit/format.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest"
+import { renderEvent, type SdkMessageLike } from "../../../src-v2/format.js"
+
+describe("format: renderEvent", () => {
+  it("renders assistant text", () => {
+    const msg: SdkMessageLike = {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello world" }] },
+    }
+    expect(renderEvent(msg)).toBe("Hello world")
+  })
+
+  it("renders tool_use as one line with arrow", () => {
+    const msg: SdkMessageLike = {
+      type: "assistant",
+      message: { content: [{ type: "tool_use", name: "Read", input: { file_path: "src/x.ts" } }] },
+    }
+    expect(renderEvent(msg)).toBe("→ Read src/x.ts")
+  })
+
+  it("summarizes Bash command on one line", () => {
+    const msg: SdkMessageLike = {
+      type: "assistant",
+      message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm typecheck" } }] },
+    }
+    expect(renderEvent(msg)).toBe("→ Bash: pnpm typecheck")
+  })
+
+  it("renders tool_result as size summary by default", () => {
+    const msg: SdkMessageLike = {
+      type: "user",
+      message: { content: [{ type: "tool_result", content: "line1\nline2\nline3" }] },
+    }
+    const result = renderEvent(msg)
+    expect(result).toMatch(/3 lines/)
+    expect(result).not.toMatch(/line1/)
+  })
+
+  it("includes raw content when verbose=true", () => {
+    const msg: SdkMessageLike = {
+      type: "user",
+      message: { content: [{ type: "tool_result", content: "hello world" }] },
+    }
+    const result = renderEvent(msg, { verbose: true })
+    expect(result).toMatch(/hello world/)
+  })
+
+  it("flags errored tool_result", () => {
+    const msg: SdkMessageLike = {
+      type: "user",
+      message: { content: [{ type: "tool_result", content: "boom", is_error: true }] },
+    }
+    const result = renderEvent(msg)
+    expect(result).toMatch(/ERROR/)
+  })
+
+  it("formats result with success tag and timing", () => {
+    const msg: SdkMessageLike = {
+      type: "result",
+      subtype: "success",
+      duration_ms: 12_500,
+      num_turns: 8,
+      total_cost_usd: 0.0125,
+    }
+    const result = renderEvent(msg)
+    expect(result).toMatch(/DONE/)
+    expect(result).toMatch(/12\.5s/)
+    expect(result).toMatch(/8 turns/)
+    expect(result).toMatch(/\$0\.0125/)
+  })
+
+  it("formats result with FAILED tag for non-success", () => {
+    const msg: SdkMessageLike = { type: "result", subtype: "error_max_turns" }
+    const result = renderEvent(msg)
+    expect(result).toMatch(/FAILED/)
+    expect(result).toMatch(/error_max_turns/)
+  })
+
+  it("returns null for system messages", () => {
+    expect(renderEvent({ type: "system" })).toBeNull()
+  })
+
+  it("quiet=true suppresses everything except result", () => {
+    const tu: SdkMessageLike = {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "hi" }] },
+    }
+    expect(renderEvent(tu, { quiet: true })).toBeNull()
+    const r: SdkMessageLike = { type: "result", subtype: "success" }
+    expect(renderEvent(r, { quiet: true })).toMatch(/DONE/)
+  })
+})

--- a/tests/lean/unit/issue.test.ts
+++ b/tests/lean/unit/issue.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest"
+import { truncate } from "../../../src-v2/issue.js"
+
+describe("issue: truncate", () => {
+  it("returns string unchanged when within limit", () => {
+    expect(truncate("hello", 100)).toBe("hello")
+  })
+
+  it("truncates long strings with ellipsis suffix", () => {
+    const result = truncate("x".repeat(100), 50)
+    expect(result.startsWith("x".repeat(50))).toBe(true)
+    expect(result).toMatch(/\+50 chars/)
+  })
+
+  it("does not error on empty string", () => {
+    expect(truncate("", 100)).toBe("")
+  })
+
+  it("handles exact-length input", () => {
+    expect(truncate("12345", 5)).toBe("12345")
+  })
+})

--- a/tests/lean/unit/litellm.test.ts
+++ b/tests/lean/unit/litellm.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest"
+import { generateLitellmConfigYaml } from "../../../src-v2/litellm.js"
+
+describe("litellm: generateLitellmConfigYaml", () => {
+  it("emits a model_list with provider/model and api_key env var", () => {
+    const yaml = generateLitellmConfigYaml({ provider: "minimax", model: "MiniMax-M2.7-highspeed" })
+    expect(yaml).toMatch(/model_list:/)
+    expect(yaml).toMatch(/model_name: MiniMax-M2\.7-highspeed/)
+    expect(yaml).toMatch(/model: minimax\/MiniMax-M2\.7-highspeed/)
+    expect(yaml).toMatch(/api_key: os\.environ\/MINIMAX_API_KEY/)
+  })
+
+  it("includes drop_params: true to silence non-anthropic warnings", () => {
+    const yaml = generateLitellmConfigYaml({ provider: "openai", model: "gpt-4o" })
+    expect(yaml).toMatch(/drop_params: true/)
+  })
+
+  it("derives api_key env var from provider name", () => {
+    const yaml = generateLitellmConfigYaml({ provider: "openai", model: "gpt-4o" })
+    expect(yaml).toMatch(/api_key: os\.environ\/OPENAI_API_KEY/)
+  })
+})

--- a/tests/lean/unit/pr.test.ts
+++ b/tests/lean/unit/pr.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+import { buildPrTitle, buildPrBody } from "../../../src-v2/pr.js"
+
+describe("pr: buildPrTitle", () => {
+  it("formats issue number and title", () => {
+    expect(buildPrTitle(42, "Add feature X", false)).toBe("#42: Add feature X")
+  })
+
+  it("prefixes draft with [WIP]", () => {
+    expect(buildPrTitle(42, "Add X", true)).toBe("[WIP] #42: Add X")
+  })
+
+  it("truncates long titles to 72 chars", () => {
+    const long = "x".repeat(200)
+    const result = buildPrTitle(1, long, false)
+    expect(result.length).toBeLessThanOrEqual(72)
+    expect(result.endsWith("…")).toBe(true)
+  })
+})
+
+describe("pr: buildPrBody", () => {
+  const baseOpts = {
+    branch: "1-foo",
+    defaultBranch: "main",
+    issueNumber: 5,
+    issueTitle: "Add Y",
+    draft: false,
+    changedFiles: ["src/foo.ts", "src/bar.ts"],
+    cwd: ".",
+  }
+
+  it("includes Summary section and Closes #N", () => {
+    const body = buildPrBody(baseOpts)
+    expect(body).toMatch(/## Summary/)
+    expect(body).toMatch(/Closes #5/)
+  })
+
+  it("includes Changes list with backticked file names", () => {
+    const body = buildPrBody(baseOpts)
+    expect(body).toMatch(/## Changes/)
+    expect(body).toMatch(/`src\/foo\.ts`/)
+    expect(body).toMatch(/`src\/bar\.ts`/)
+  })
+
+  it("prefixes draft body with FAILED warning", () => {
+    const body = buildPrBody({ ...baseOpts, draft: true, failureReason: "tests failed" })
+    expect(body.startsWith("> ⚠️ FAILED: tests failed")).toBe(true)
+  })
+
+  it("truncates failure reason to 2KB", () => {
+    const huge = "x".repeat(5000)
+    const body = buildPrBody({ ...baseOpts, draft: true, failureReason: huge })
+    const failedLine = body.split("\n")[0]!
+    expect(failedLine.length).toBeLessThan(2200)
+  })
+
+  it("omits Changes section when no files changed", () => {
+    const body = buildPrBody({ ...baseOpts, changedFiles: [] })
+    expect(body).not.toMatch(/## Changes/)
+  })
+
+  it("caps Changes list at 50 entries", () => {
+    const many = Array.from({ length: 60 }, (_, i) => `src/file${i}.ts`)
+    const body = buildPrBody({ ...baseOpts, changedFiles: many })
+    const matches = body.match(/`src\/file\d+\.ts`/g) ?? []
+    expect(matches.length).toBe(50)
+    expect(body).toMatch(/and 10 more/)
+  })
+})

--- a/tests/lean/unit/prompt.test.ts
+++ b/tests/lean/unit/prompt.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest"
+import { buildPrompt, parseAgentResult } from "../../../src-v2/prompt.js"
+import type { KodyLeanConfig } from "../../../src-v2/config.js"
+
+const baseConfig: KodyLeanConfig = {
+  quality: { typecheck: "pnpm tc", testUnit: "pnpm test", lint: "" },
+  git: { defaultBranch: "main" },
+  github: { owner: "o", repo: "r" },
+  agent: { model: "minimax/m" },
+}
+
+describe("prompt: buildPrompt", () => {
+  it("includes issue body, branch, and quality commands", () => {
+    const p = buildPrompt({
+      config: baseConfig,
+      issue: { number: 42, title: "Add X", body: "BODY HERE", comments: [] },
+      featureBranch: "42-add-x",
+    })
+    expect(p).toMatch(/Add X/)
+    expect(p).toMatch(/BODY HERE/)
+    expect(p).toMatch(/42-add-x/)
+    expect(p).toMatch(/pnpm tc/)
+    expect(p).toMatch(/pnpm test/)
+  })
+
+  it("omits empty quality commands", () => {
+    const p = buildPrompt({
+      config: baseConfig,
+      issue: { number: 1, title: "x", body: "", comments: [] },
+      featureBranch: "1-x",
+    })
+    expect(p).not.toMatch(/^- lint:/m)
+  })
+
+  it("includes lint when configured", () => {
+    const cfg = { ...baseConfig, quality: { ...baseConfig.quality, lint: "pnpm lint" } }
+    const p = buildPrompt({
+      config: cfg,
+      issue: { number: 1, title: "x", body: "", comments: [] },
+      featureBranch: "1-x",
+    })
+    expect(p).toMatch(/pnpm lint/)
+  })
+
+  it("includes recent comments most-recent-first, capped at 5", () => {
+    const comments = Array.from({ length: 8 }, (_, i) => ({
+      body: `comment ${i}`,
+      author: `user${i}`,
+      createdAt: `2026-04-0${i + 1}`,
+    }))
+    const p = buildPrompt({
+      config: baseConfig,
+      issue: { number: 1, title: "x", body: "", comments },
+      featureBranch: "1-x",
+    })
+    expect(p).toMatch(/comment 7/)
+    expect(p).toMatch(/comment 3/)
+    expect(p).not.toMatch(/comment 0/)
+    const lastIdx = p.indexOf("comment 7")
+    const firstIdx = p.indexOf("comment 3")
+    expect(lastIdx).toBeLessThan(firstIdx)
+  })
+
+  it("truncates comments larger than 4KB", () => {
+    const huge = "x".repeat(5000)
+    const p = buildPrompt({
+      config: baseConfig,
+      issue: { number: 1, title: "x", body: "", comments: [{ body: huge, author: "u", createdAt: "" }] },
+      featureBranch: "1-x",
+    })
+    expect(p).toMatch(/truncated/)
+  })
+
+  it("instructs not to run git/gh", () => {
+    const p = buildPrompt({
+      config: baseConfig,
+      issue: { number: 1, title: "x", body: "", comments: [] },
+      featureBranch: "1-x",
+    })
+    expect(p).toMatch(/Do NOT run any `git` or `gh`/)
+  })
+})
+
+describe("prompt: parseAgentResult", () => {
+  it("parses DONE + COMMIT_MSG", () => {
+    const result = parseAgentResult("DONE\nCOMMIT_MSG: feat: add X")
+    expect(result.done).toBe(true)
+    expect(result.commitMessage).toBe("feat: add X")
+  })
+
+  it("parses FAILED with reason", () => {
+    const result = parseAgentResult("FAILED: tests broken")
+    expect(result.done).toBe(false)
+    expect(result.failureReason).toBe("tests broken")
+  })
+
+  it("returns failure when no marker present", () => {
+    const result = parseAgentResult("just some text")
+    expect(result.done).toBe(false)
+    expect(result.failureReason).toMatch(/no DONE or FAILED/)
+  })
+
+  it("returns failure when text is empty", () => {
+    const result = parseAgentResult("")
+    expect(result.done).toBe(false)
+    expect(result.failureReason).toMatch(/no final message/)
+  })
+
+  it("DONE without COMMIT_MSG returns empty commit msg", () => {
+    const result = parseAgentResult("DONE")
+    expect(result.done).toBe(true)
+    expect(result.commitMessage).toBe("")
+  })
+
+  it("ignores surrounding text around DONE marker", () => {
+    const result = parseAgentResult("All set!\n\nDONE\nCOMMIT_MSG: chore: tidy")
+    expect(result.done).toBe(true)
+    expect(result.commitMessage).toBe("chore: tidy")
+  })
+})

--- a/tests/lean/unit/prompt.test.ts
+++ b/tests/lean/unit/prompt.test.ts
@@ -77,7 +77,7 @@ describe("prompt: buildPrompt", () => {
       issue: { number: 1, title: "x", body: "", comments: [] },
       featureBranch: "1-x",
     })
-    expect(p).toMatch(/Do NOT run any `git` or `gh`/)
+    expect(p).toMatch(/Do NOT run \*\*any\*\* `git` or `gh` commands/)
   })
 })
 

--- a/tests/lean/unit/verify.test.ts
+++ b/tests/lean/unit/verify.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest"
+import { verifyAll, summarizeFailure } from "../../../src-v2/verify.js"
+import type { KodyLeanConfig } from "../../../src-v2/config.js"
+
+const baseConfig: KodyLeanConfig = {
+  quality: { typecheck: "", testUnit: "", lint: "" },
+  git: { defaultBranch: "main" },
+  github: { owner: "o", repo: "r" },
+  agent: { model: "m/x" },
+}
+
+describe("verify: verifyAll", () => {
+  it("returns ok when no commands configured", async () => {
+    const result = await verifyAll(baseConfig)
+    expect(result.ok).toBe(true)
+    expect(result.failed).toEqual([])
+  })
+
+  it("captures exit code 0 as success", async () => {
+    const cfg: KodyLeanConfig = { ...baseConfig, quality: { ...baseConfig.quality, typecheck: "true" } }
+    const result = await verifyAll(cfg)
+    expect(result.ok).toBe(true)
+    expect(result.details.typecheck?.exitCode).toBe(0)
+  })
+
+  it("captures non-zero exit as failure", async () => {
+    const cfg: KodyLeanConfig = { ...baseConfig, quality: { ...baseConfig.quality, typecheck: "false" } }
+    const result = await verifyAll(cfg)
+    expect(result.ok).toBe(false)
+    expect(result.failed).toContain("typecheck")
+  })
+
+  it("runs all configured commands", async () => {
+    const cfg: KodyLeanConfig = {
+      ...baseConfig,
+      quality: { typecheck: "true", testUnit: "true", lint: "false" },
+    }
+    const result = await verifyAll(cfg)
+    expect(result.failed).toEqual(["lint"])
+    expect(Object.keys(result.details).sort()).toEqual(["lint", "test", "typecheck"])
+  })
+})
+
+describe("verify: summarizeFailure", () => {
+  it("includes failed command names in summary", () => {
+    const summary = summarizeFailure({
+      ok: false,
+      failed: ["typecheck", "test"],
+      details: {
+        typecheck: { exitCode: 1, durationMs: 1000, tail: "TS error here" },
+        test: { exitCode: 1, durationMs: 2000, tail: "test failed" },
+      },
+    })
+    expect(summary).toMatch(/typecheck/)
+    expect(summary).toMatch(/test/)
+    expect(summary).toMatch(/TS error here/)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "declaration": true,
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src", "src-v2", "bin-v2"],
+  "exclude": ["node_modules", "dist", "e2e"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,17 +1,30 @@
 import { defineConfig } from "tsup"
 
-export default defineConfig({
-  entry: ["src/bin/cli.ts"],
-  format: ["esm"],
-  outDir: "dist/bin",
-  splitting: false,
-  clean: true,
-  dts: false,
-  sourcemap: false,
-  bundle: true,
-  platform: "node",
-  target: "node22",
-  banner: {
-    js: "#!/usr/bin/env node",
+export default defineConfig([
+  {
+    entry: ["src/bin/cli.ts"],
+    format: ["esm"],
+    outDir: "dist/bin",
+    splitting: false,
+    clean: true,
+    dts: false,
+    sourcemap: false,
+    bundle: true,
+    platform: "node",
+    target: "node22",
+    banner: { js: "#!/usr/bin/env node" },
   },
-})
+  {
+    entry: ["bin-v2/kody-lean.ts"],
+    format: ["esm"],
+    outDir: "dist/bin-v2",
+    splitting: false,
+    clean: false,
+    dts: false,
+    sourcemap: false,
+    bundle: true,
+    platform: "node",
+    target: "node22",
+    banner: { js: "#!/usr/bin/env node" },
+  },
+])


### PR DESCRIPTION
## Summary

Adds a parallel implementation of the autonomous engine that **collapses the 7-stage pipeline into a single Claude Code SDK session**. The wrapper handles all deterministic operations (branch, commit, push, PR, comments, verify); the agent only does research → plan → build → iterate-on-quality.

## Why

Bug hotspots in the existing pipeline cluster at **stage boundaries**, not inside any one stage:
- Fix-mode scope leaks across stages (7 recent fixes)
- State races in `.kody/tasks/` and event-log (5 recent fixes)
- Session-handoff drift between explore/build/review sessions
- CI sequencing between parse/orchestrate/summarize jobs (6 recent fixes)

A single session has no boundaries to fail at. Reduction: **27,459 LOC (old src/) → ~700 LOC (src-v2/)**, with the same end-to-end capability.

## What ships

- `src-v2/` — config, litellm, agent, format, branch, commit, pr, verify, issue, prompt, index, entry. No state files, no retries, no event-log.
- `bin-v2/kody-lean.ts` — CLI: `kody-lean run --issue <N>`
- `.github/workflows/kody-lean.yml` — single-job workflow triggered by `workflow_dispatch` or `@kody2` issue comments (filters out PR comments)
- `.github/workflows/kody-lean-tests.yml` — typecheck + unit + int + e2e on every PR
- `tests/lean/` — 92 unit + integration tests
- `e2e/` — 7 CLI smoke tests
- `kody.config.json`: adds `agent.model` (single field) alongside legacy `modelMap`
- `tsconfig.json` + `tsup.config.ts`: include `src-v2/` and `bin-v2/`

## Coexistence

Old `src/`, `bin/`, `kody.yml` workflow stay **untouched**. The lean pipeline triggers on **`@kody2`**; the existing one still triggers on `@kody`. Deletion of the 7-stage code happens only after lean is proven on more real issues.

## Battle-test results

Two live runs against Kody-Engine-Tester proved the pipeline end-to-end:

1. **Issue #2855** (README tagline edit) — agent edited `README.md`, draft PR opened with proper title/body/`Closes #N` (verify failed on pre-existing tester issues, hence draft)
2. **Issue #2857** (medium: create `/api/healthz` endpoint) — agent created `route.ts` + `route.test.ts`, both clean across all quality gates, draft PR opened

Bugs surfaced and fixed during battle-testing:
- Untracked-file false positive in WIP guard
- Missing `git stderr` in error reporting
- `.trim()` stripping leading space from porcelain status (caused empty git-add)
- ANSI escapes leaking into PR body

## Test plan

- [x] All 92 lean unit + integration tests pass (`pnpm test:lean`)
- [x] All 7 E2E CLI smoke tests pass
- [x] `pnpm typecheck` passes (both old and new code)
- [x] `pnpm build` produces both `dist/bin/cli.js` and `dist/bin-v2/kody-lean.js`
- [x] Two live runs on Kody-Engine-Tester opened correct draft PRs
- [ ] Pipeline coexistence verified (old `@kody` still triggers old workflow, new `@kody2` triggers new)
- [ ] More live runs on harder issues (planned post-merge)

## Stance going forward

- Old pipeline coexists for 2-4 weeks
- Add guards only based on real-run evidence (not speculation)
- Fix-mode (`@kody fix`) deferred until `run` is proven on 5–10 issues
- Old `src/` deleted in one commit once lean has handled real workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)