### PR TITLE
fix(kody.yml): export project secrets before pnpm install

### DIFF
--- a/.github/workflows/kody.yml
+++ b/.github/workflows/kody.yml
@@ -197,10 +197,19 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
-
+      # Must run before `pnpm install` so postinstall hooks that rely on
+      # repo secrets (e.g. Payload `generate:types` reading DATABASE_URL)
+      # see them. `kody-engine` is provided by the engine package below, so
+      # we install it before exporting so the command is on PATH.
       - name: Install Kody Engine
         run: npm install -g @kody-ade/engine
+
+      - name: Export project secrets
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: kody-engine ci-export-secrets
+
+      - run: pnpm install --frozen-lockfile
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
@@ -212,11 +221,6 @@ jobs:
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-
-      - name: Export project secrets
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-        run: kody-engine ci-export-secrets
 
       - name: Run Kody pipeline
         env:
@@ -496,6 +500,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      # Install kody-engine + export secrets BEFORE `pnpm install` so
+      # postinstall hooks (e.g. Payload `generate:types` reading DATABASE_URL)
+      # see repo secrets.
+      - name: Install kody-engine
+        run: npm install -g @kody-ade/engine@latest --force
+
+      - name: Export project secrets
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: kody-engine ci-export-secrets
+
       - run: pnpm install --frozen-lockfile
 
       - name: Install Claude Code CLI
@@ -505,14 +520,6 @@ jobs:
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-
-      - name: Export project secrets
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-        run: kody-engine ci-export-secrets
-
-      - name: Install kody-engine
-        run: npm install -g @kody-ade/engine@latest --force
 
       - name: Run chat session
         env:


### PR DESCRIPTION
## Problem

Every kody mode (run/rerun/fix/review/...) fails during setup on target repos whose `postinstall` reads env vars:

```
Error: DATABASE_URL environment variable is required but not set.
```

Root cause: `.github/workflows/kody.yml` runs `Export project secrets` **after** `pnpm install --frozen-lockfile`. The postinstall hook therefore sees an empty environment.

Observed on A-Guy PR #1323 ([run 24837137403](https://github.com/A-Guy-educ/A-Guy/actions/runs/24837137403)).

## Fix

Move `Install Kody Engine` + `Export project secrets` directly after `setup-node` / `pnpm/action-setup` and **before** `pnpm install` in both the orchestrate job and the chat job.

Also fixes a pre-existing ordering issue in the chat job where `kody-engine ci-export-secrets` was invoked before the engine was installed.

`templates/kody.yml` is a symlink to `.github/workflows/kody.yml`, so one edit covers both the engine's own workflow and the canonical template shipped to target repos.

## Test plan

- [ ] Engine self-test CI stays green
- [ ] Re-run `@kody review` on [A-Guy PR #1323](https://github.com/A-Guy-educ/A-Guy/pull/1323) once the target-repo mirror (A-Guy PR #1324) lands — review should complete and post